### PR TITLE
change tempfiles creation to add the correct extension

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -761,11 +761,14 @@ static bool read_ir_file(compilation_unit_t *unit)
 }
 
 static int compilation_loop(compile_mode_t mode, compilation_unit_t *units,
-							lang_standard_t standard, FILE *out)
+                            lang_standard_t standard, FILE *out)
 {
-	int  result                   = EXIT_SUCCESS;
+	int  result = EXIT_SUCCESS;
+	char tmpname[128];  /* used to change input filename extension */
+
 	for (compilation_unit_t *unit = units; unit != NULL; unit = unit->next) {
-		const char *const inputname = unit->name;
+		const char *const inputname = unit->name ?
+			unit->name : "stdin.c";
 
 		determine_unit_standard(unit, standard);
 
@@ -870,7 +873,8 @@ again:
 			if (mode == MODE_COMPILE) {
 				asm_out = out;
 			} else {
-				asm_out = make_temp_file("ccs", &unit->name);
+				get_output_name(tmpname, sizeof(tmpname)-1, inputname, ".s");
+				asm_out = make_temp_file(tmpname, &unit->name);
 			}
 			ir_timer_t *t_opt_codegen = ir_timer_new();
 			timer_register(t_opt_codegen, "Optimization and Codegeneration");
@@ -897,7 +901,8 @@ again:
 				fclose(out);
 				unit->name = outname;
 			} else {
-				FILE *tempf = make_temp_file("cco", &unit->name);
+				get_output_name(tmpname, sizeof(tmpname)-1, inputname, ".o");
+				FILE *tempf = make_temp_file(tmpname, &unit->name);
 				/* hackish... */
 				fclose(tempf);
 			}

--- a/enable_posix.h
+++ b/enable_posix.h
@@ -19,6 +19,7 @@
 #define fdopen(fd, mode)         _fdopen(fd, mode)
 #define isatty(fd)               _isatty(fd)
 #define mktemp(tmpl)             _mktemp(tmpl)
+#define mkdir(name, mode)        _mkdir(name)
 #define open(fname, oflag, mode) _open(fname, oflag, mode)
 #define pclose(file)             _pclose(file)
 #define popen(cmd, mode)         _popen(cmd, mode)
@@ -28,7 +29,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <unistd.h>
 #include <sys/stat.h>
-#define HAVE_MKSTEMP
+#define HAVE_MKDTEMP
 #define HAVE_FILENO
 #define HAVE_ASCTIME_R
 #define HAVE_FSTAT

--- a/tempfile.c
+++ b/tempfile.c
@@ -86,6 +86,9 @@ static const char *make_tempsubdir(const char *tempdir)
 
 FILE *make_temp_file(const char *name_orig, const char **name_result)
 {
+	if (tempsubdir == NULL)
+		tempsubdir = make_tempsubdir(get_tempdir());
+
 	assert(obstack_object_size(&file_obst) == 0);
 	obstack_printf(&file_obst, "%s/%s", tempsubdir, name_orig);
 	obstack_1grow(&file_obst, '\0');
@@ -107,7 +110,7 @@ void init_temp_files(void)
 {
 	obstack_init(&file_obst);
 
-	tempsubdir = make_tempsubdir(get_tempdir());
+	tempsubdir = NULL;
 	temp_files = NEW_ARR_F(char*, 0);
 	atexit(free_temp_files);
 }
@@ -125,8 +128,11 @@ void free_temp_files(void)
 	}
 	DEL_ARR_F(temp_files);
 	temp_files = NULL;
-	
-	remove(tempsubdir);
+
+	if (tempsubdir != NULL) {
+		remove(tempsubdir);
+		tempsubdir = NULL;
+	}
 
 	obstack_free(&file_obst, NULL);
 }

--- a/tempfile.c
+++ b/tempfile.c
@@ -16,6 +16,7 @@
 
 static char         **temp_files;
 static struct obstack file_obst;
+static const char    *tempsubdir;
 
 static const char *try_dir(const char *dir)
 {
@@ -58,32 +59,43 @@ static const char *get_tempdir(void)
 	return tmpdir;
 }
 
-#ifndef HAVE_MKSTEMP
-/* cheap and nasty mkstemp replacement */
-static int mkstemp(char *templ)
+#ifndef HAVE_MKDTEMP
+/* cheap and nasty mkdtemp replacement */
+static int mkdtemp(char *templ)
 {
 	mktemp(templ);
-	return open(templ, O_RDWR|O_CREAT|O_EXCL|O_BINARY, 0600);
+	return mkdir(templ, 0700);
 }
 #endif
 
-FILE *make_temp_file(const char *prefix, const char **name_result)
+static const char *make_tempsubdir(const char *tempdir)
 {
-	const char *tempdir = get_tempdir();
 	assert(obstack_object_size(&file_obst) == 0);
-	obstack_printf(&file_obst, "%s/%sXXXXXX", tempdir, prefix);
+	obstack_printf(&file_obst, "%s/XXXXXX", tempdir);
+	obstack_1grow(&file_obst, '\0');
+
+	char *templ = obstack_finish(&file_obst);
+	const char *dir = mkdtemp(templ);
+	if (dir == NULL) {
+		fprintf(stderr, "error: mkdtemp could not create a directory"
+			" from template: %s\n", templ);
+		panic("abort");
+	}
+	return dir;
+}
+
+FILE *make_temp_file(const char *name_orig, const char **name_result)
+{
+	assert(obstack_object_size(&file_obst) == 0);
+	obstack_printf(&file_obst, "%s/%s", tempsubdir, name_orig);
 	obstack_1grow(&file_obst, '\0');
 
 	char *name = obstack_finish(&file_obst);
-	int fd = mkstemp(name);
-	if (fd == -1) {
+	FILE *out = fopen(name, "w");
+	if (out == NULL) {
 		fprintf(stderr, "error: could not create temporary file: %s",
 		        strerror(errno));
 		panic("abort");
-	}
-	FILE *out = fdopen(fd, "w");
-	if (out == NULL) {
-		panic("could not open temporary file as FILE*");
 	}
 
 	ARR_APP1(char*, temp_files, name);
@@ -93,10 +105,11 @@ FILE *make_temp_file(const char *prefix, const char **name_result)
 
 void init_temp_files(void)
 {
+	obstack_init(&file_obst);
+
+	tempsubdir = make_tempsubdir(get_tempdir());
 	temp_files = NEW_ARR_F(char*, 0);
 	atexit(free_temp_files);
-
-	obstack_init(&file_obst);
 }
 
 void free_temp_files(void)
@@ -112,6 +125,8 @@ void free_temp_files(void)
 	}
 	DEL_ARR_F(temp_files);
 	temp_files = NULL;
+	
+	remove(tempsubdir);
 
 	obstack_free(&file_obst, NULL);
 }

--- a/tempfile.h
+++ b/tempfile.h
@@ -4,10 +4,10 @@
 #include <stdio.h>
 
 /**
- * custom version of tmpnam, which: writes to an obstack, emits no warnings
- * during linking (like glibc/gnu ld do for tmpnam)...
+ * Creates temporary files named $name_orig inside a temporary
+ * directory created with mkdtemp().
  */
-FILE *make_temp_file(const char *prefix, const char **name_result);
+FILE *make_temp_file(const char *name_orig, const char **name_result);
 
 void init_temp_files(void);
 void free_temp_files(void);


### PR DESCRIPTION
We now create a temporary directory which contains the .s and .o
files. The original filename is kept. This allows us to work
more easily with other compilers than gcc.
