### PR TITLE
implementation of issue148: X is a gnu extension should be a warning.

### DIFF
--- a/src/driver/warning.h
+++ b/src/driver/warning.h
@@ -40,6 +40,7 @@ void print_warning_opt_help(void);
 	M(WARN_FATAL_ERRORS,                  OFF, "fatal-errors",                  "First error stops the compilation") \
 	M(WARN_FLOAT_EQUAL,                   OFF, "float-equal",                   "Warn if floating point values are used in equality comparisons") \
 	M(WARN_FORMAT,                        ON,  "format",                        "Check printf-style format strings") \
+	M(WARN_GNU_EXTENSION,                 ON,  "disabled-gnu-extension-usage",  "Warn when a gnu extension is used while gnu modes are not used") \
 	M(WARN_IGNORED_QUALIFIERS,            ON,  "ignored-qualifiers",            "Warn when type qualifiers are meaningless") \
 	M(WARN_IMPLICIT_FUNCTION_DECLARATION, ON,  "implicit-function-declaration", "Warn whenever a function is used before being declared") \
 	M(WARN_IMPLICIT_INT,                  ON,  "implicit-int",                  "Warn when a declaration does not specify a type") \

--- a/src/driver/warning.h
+++ b/src/driver/warning.h
@@ -40,7 +40,6 @@ void print_warning_opt_help(void);
 	M(WARN_FATAL_ERRORS,                  OFF, "fatal-errors",                  "First error stops the compilation") \
 	M(WARN_FLOAT_EQUAL,                   OFF, "float-equal",                   "Warn if floating point values are used in equality comparisons") \
 	M(WARN_FORMAT,                        ON,  "format",                        "Check printf-style format strings") \
-	M(WARN_GNU_EXTENSION,                 ON,  "disabled-gnu-extension-usage",  "Warn when a gnu extension is used while gnu modes are not used") \
 	M(WARN_IGNORED_QUALIFIERS,            ON,  "ignored-qualifiers",            "Warn when type qualifiers are meaningless") \
 	M(WARN_IMPLICIT_FUNCTION_DECLARATION, ON,  "implicit-function-declaration", "Warn whenever a function is used before being declared") \
 	M(WARN_IMPLICIT_INT,                  ON,  "implicit-int",                  "Warn when a declaration does not specify a type") \

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -3531,8 +3531,7 @@ static type_t *construct_declarator_type(construct_type_t *construct_list,
 							errorf(&size_expression->base.pos, "size of array must be greater than zero");
 						} else if (size == 0 && !GNU_MODE) {
 							warningf(WARN_GNU_EXTENSION, &size_expression->base.pos,
-								"size of array must be greater than zero \
-								(zero length arrays are a GCC extension)");
+								"size of array must be greater than zero (zero length arrays are a GCC extension)");
 						}
 					} else {
 						errorf(&size_expression->base.pos, "array is too large");
@@ -5213,8 +5212,15 @@ static void parse_external_declaration(void)
 
 	position_t const *const pos = &ndeclaration->base.pos;
 	if (current_scope != file_scope) {
-		warningf(GNU_MODE? WARN_PEDANTIC: WARN_GNU_EXTENSION, pos,
-			"nested function %N is a GCC extension", ndeclaration);
+		bool printed_warning = false;
+		if (!GNU_MODE) {
+			printed_warning = warningf(WARN_GNU_EXTENSION, pos,
+				"nested function %N is a GCC extension", ndeclaration);
+		}
+		if (!printed_warning) {
+			warningf(WARN_PEDANTIC, pos,
+				"nested function %N is a GCC extension", ndeclaration);
+		}
 	}
 
 	if (is_typeref(orig_type))

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1906,7 +1906,7 @@ static initializer_t *parse_sub_initializer(type_path_t *path,
 			                                ^~~~~~~~~~~~~~~~~
 			   obsolete since GCC 2.5 */
 			if (!GNU_MODE)
-				warningf(WARN_GNU_EXTENSION, HERE, "designator with ':' is a GCC extension");
+				warningf(WARN_PEDANTIC, HERE, "designator with ':' is a GCC extension");
 			designator         = allocate_ast_zero(sizeof(designator[0]));
 			designator->pos    = *HERE;
 			designator->symbol = token.base.symbol;
@@ -3530,7 +3530,7 @@ static type_t *construct_declarator_type(construct_type_t *construct_list,
 						if (size < 0) {
 							errorf(&size_expression->base.pos, "size of array must be greater than zero");
 						} else if (size == 0 && !GNU_MODE) {
-							warningf(WARN_GNU_EXTENSION, &size_expression->base.pos,
+							warningf(WARN_PEDANTIC, &size_expression->base.pos,
 								"size of array must be greater than zero (zero length arrays are a GCC extension)");
 						}
 					} else {
@@ -5212,15 +5212,8 @@ static void parse_external_declaration(void)
 
 	position_t const *const pos = &ndeclaration->base.pos;
 	if (current_scope != file_scope) {
-		bool printed_warning = false;
-		if (!GNU_MODE) {
-			printed_warning = warningf(WARN_GNU_EXTENSION, pos,
-				"nested function %N is a GCC extension", ndeclaration);
-		}
-		if (!printed_warning) {
-			warningf(WARN_PEDANTIC, pos,
-				"nested function %N is a GCC extension", ndeclaration);
-		}
+		warningf(WARN_PEDANTIC, pos,
+			"nested function %N is a GCC extension", ndeclaration);
 	}
 
 	if (is_typeref(orig_type))
@@ -5455,7 +5448,7 @@ static void parse_bitfield_member(entity_t *entity)
 	type_t *skipped = skip_typeref(type);
 	if (is_type_integer(skipped)) {
 		if (!GNU_MODE && is_type_enum(skipped))
-			warningf(WARN_GNU_EXTENSION, &entity->base.pos,
+			warningf(WARN_PEDANTIC, &entity->base.pos,
 			       "enum type '%T' as bitfield base is a GCC extension", type);
 
 		long size_long;
@@ -6666,7 +6659,7 @@ static label_t *get_label(char const *const context)
 static expression_t *parse_label_address(void)
 {
 	if (!GNU_MODE)
-		warningf(WARN_GNU_EXTENSION, HERE, "taking address of a label is a GCC extension");
+		warningf(WARN_PEDANTIC, HERE, "taking address of a label is a GCC extension");
 
 	position_t const pos = *HERE;
 	eat(T_ANDAND);
@@ -7447,7 +7440,7 @@ static expression_t *parse_conditional_expression(expression_t *expression)
 	bool          gnu_cond = false;
 	if (peek(':')) {
 		if (!GNU_MODE)
-			warningf(WARN_GNU_EXTENSION, HERE,
+			warningf(WARN_PEDANTIC, HERE,
 				"omitting consequence of conditional expression is a GCC extension");
 		gnu_cond = true;
 	} else {
@@ -7721,7 +7714,7 @@ static void semantic_incdec(unary_expression_t *expression)
 			errorf(pos, "operation needs a real or pointer type, but got '%T'", type);
 			orig_type = type = type_error_type;
 		} else if (!GNU_MODE) {
-			warningf(WARN_GNU_EXTENSION, pos, "operation on '%T' is a GCC extension", type);
+			warningf(WARN_PEDANTIC, pos, "operation on '%T' is a GCC extension", type);
 		}
 	}
 	if (!is_lvalue(value))
@@ -9458,7 +9451,7 @@ static statement_t *parse_case_statement(void)
 	rem_anchor_token(T_DOTDOTDOT);
 	if (accept(T_DOTDOTDOT)) {
 		if (!GNU_MODE)
-			warningf(WARN_GNU_EXTENSION, pos, "case ranges are a GCC extension");
+			warningf(WARN_PEDANTIC, pos, "case ranges are a GCC extension");
 		expression_t *end_range
 			= parse_integer_constant_expression("case range end");
 		if (end_range->base.type == type_error_type) {
@@ -9893,7 +9886,7 @@ static statement_t *parse_goto(void)
 	statement_t *statement;
 	if (peek_ahead('*')) {
 		if (!GNU_MODE)
-			warningf(WARN_GNU_EXTENSION, HERE, "computed goto is a GCC extension");
+			warningf(WARN_PEDANTIC, HERE, "computed goto is a GCC extension");
 		statement = allocate_statement_zero(STATEMENT_COMPUTED_GOTO);
 		eat(T_goto);
 		eat('*');


### PR DESCRIPTION
Initial implementation of issue 148:
http://pp.ipd.kit.edu/~firm/bugs/view.php?id=148
"Currently we produce an error for some gnu extensions when a non-gnu standard is selected. This is unnecessary a warning would be enough, people could still say -Werror=gnu-extension (name not decided yet) to turn it into an error if they want to."

Lines at approx 5919, 6899, 7653 and 7664 haven't been changed since I wasn't too sure about their correct implementation for the above issue.
