### PR TITLE
A few quality of life improvements to the driver.

### DIFF
--- a/cparser.1
+++ b/cparser.1
@@ -101,6 +101,8 @@ Set target, for which code is generated.
 .Cm midipix*
 .It
 .Cm mingw*
+.It
+.Cm openbsd*
 .El
 .It Fl ansi
 .No Same as Fl std=c90 Po for C Pc No or Fl std=c++98 Pq for C++ .

--- a/src/driver/options.c
+++ b/src/driver/options.c
@@ -366,6 +366,7 @@ bool options_parse_linker(options_state_t *s)
 		driver_add_flag(&ldflags_obst, "-L%s", arg);
 	} else if (simple_arg("static", s)
 	        || simple_arg("no-pie", s)
+	        || simple_arg("nopie", s)
 	        || simple_arg("nodefaultlibs", s)
 	        || simple_arg("nostartfiles", s)
 	        || simple_arg("nostdlib", s)
@@ -384,6 +385,8 @@ bool options_parse_linker(options_state_t *s)
 	} else if (simple_arg("pg", s)) {
 		set_target_option("gprof");
 		driver_add_flag(&ldflags_obst, "-pg");
+	} else if ((arg = equals_arg("fuse-ld", s)) != NULL) {
+		driver_add_flag(&ldflags_obst, "-fuse-ld=%s", arg);
 	} else if ((arg = equals_arg("print-file-name", s)) != NULL) {
 		print_file_name_file = arg;
 		s->action = action_print_file_name;

--- a/src/driver/target.c
+++ b/src/driver/target.c
@@ -245,6 +245,11 @@ void init_firm_target(void)
 		errorf(NULL, "Failed to initialize libfirm code generation\n");
 		exit(EXIT_FAILURE);
 	}
+
+	if (strstart(ir_triple_get_operating_system(target.machine), "openbsd")) {
+		target.pic = true;
+		target.set_pic = true;
+	}
 }
 
 bool target_setup(void)


### PR DESCRIPTION
Hi --

This pull requests implements a number of quality of life improvements to the cparser driver, especially but not exclusively on OpenBSD.

First, the most general quality of life improvement: teach cparser about the linker flag -fuse-ld. Both clang and gcc use this flag to link against a linker other than the installed default. gcc accepts -fuse-ld=bfd and -fuse-ld=gold while clang accepts both of those plus -fuse-ld=lld. Since cparser simply uses another C compiler for linking, I think adding this option makes sense, since I presume most users of cparser are using some sort of Unix, where clang and/or gcc is the system C compiler.

Next is to teach cparser about the -nopie option. OpenBSD uses this instead of -no-pie.

Next is to set up OpenBSD to default to -fPIC. I am not 100% sure if the location I chose in `src/driver/target.c` is the most ideal spot, but I hope the intent is clear.

Finally, add OpenBSD to the list of system targets in `cparser.1`.

Thanks!